### PR TITLE
Add Firebird >3.0 compatibility for trace configuration file builder

### DIFF
--- a/src/org/executequery/gui/browser/managment/tracemanager/BuildConfigurationPanel.java
+++ b/src/org/executequery/gui/browser/managment/tracemanager/BuildConfigurationPanel.java
@@ -79,6 +79,29 @@ public class BuildConfigurationPanel extends JPanel {
             "print_dyn",
             "log_privilege_changes",
             "log_changes_only"};
+    String[] checkDatabaseFbStrs = {
+            "log_initfini",
+            "log_connections",
+            "log_transactions",
+            "log_statement_prepare",
+            "log_statement_free",
+            "log_statement_start",
+            "log_statement_finish",
+            "log_procedure_start",
+            "log_procedure_finish",
+            "log_function_start",
+            "log_function_finish",
+            "log_trigger_start",
+            "log_trigger_finish",
+            "log_context",
+            "log_errors",
+            "log_warnings",
+            "print_plan",
+            "print_perf",
+            "log_blr_requests",
+            "print_blr",
+            "log_dyn_requests",
+            "print_dyn"};    
     String[] checkServicesStrs = {"log_services", "log_service_query"};
     String[] filters = {
             "include_user_filter",
@@ -113,7 +136,7 @@ public class BuildConfigurationPanel extends JPanel {
 
     public BuildConfigurationPanel() {
         componentMap = new HashMap<>();
-        appropriationBox = new JComboBox<>(new String[]{"RedDatabase 2.6", "RedDatabase 3.0"});
+        appropriationBox = new JComboBox<>(new String[]{"RedDatabase 2.6", "RedDatabase 3.0", "Firebird 3.0 or greater"});
         appropriationBox.addItemListener(new ItemListener() {
             @Override
             public void itemStateChanged(ItemEvent e) {
@@ -286,9 +309,19 @@ public class BuildConfigurationPanel extends JPanel {
         databasePanel.setLayout(new GridBagLayout());
         int k = 0;
         String[] checks;
-        if (appropriationBox.getSelectedIndex() == 0)
-            checks = checkDatabaseStrs;
-        else checks = checkDatabase3Strs;
+        switch (appropriationBox.getSelectedIndex()) {
+            case 0:
+                checks = checkDatabaseStrs;
+                break;
+            case 1:
+                checks = checkDatabase3Strs;
+                break;
+            case 2:
+                checks = checkDatabaseFb30Strs;
+                break;
+            default:
+                checks = checkDatabase3Strs;
+        }     
         for (int i = 0; k < checks.length; i++)
             for (int g = 0; g < x && k < checks.length; g++, k++) {
                 JCheckBox checkBox = new JCheckBox(checks[k]);
@@ -330,11 +363,22 @@ public class BuildConfigurationPanel extends JPanel {
         else sb.append("database\n{");
         sb.append("\n\n");
         sb.append("\tenabled").append(apSymbol()).append("true\n\n");
-        sb.append("\tformat").append(apSymbol()).append("0\n\n");
+        if (appropriationBox.getSelectedIndex() < 2)
+          sb.append("\tformat").append(apSymbol()).append("0\n\n");
         String[] checks;
-        if (appropriationBox.getSelectedIndex() == 0)
-            checks = checkDatabaseStrs;
-        else checks = checkDatabase3Strs;
+        switch (appropriationBox.getSelectedIndex()) {
+            case 0:
+                checks = checkDatabaseStrs;
+                break;
+            case 1:
+                checks = checkDatabase3Strs;
+                break;
+            case 2:
+                checks = checkDatabaseFb30Strs;
+                break;
+            default:
+                checks = checkDatabase3Strs;
+        }     
         for (int i = 0; i < checks.length; i++) {
             appendProp(sb, checks[i]);
         }
@@ -354,7 +398,8 @@ public class BuildConfigurationPanel extends JPanel {
         else sb.append("services\n{");
         sb.append("\n\n");
         sb.append("\tenabled").append(apSymbol()).append("true\n\n");
-        sb.append("\tformat").append(apSymbol()).append("0\n\n");
+        if (appropriationBox.getSelectedIndex() < 2)
+          sb.append("\tformat").append(apSymbol()).append("0\n\n");
         for (int i = 0; i < checkServicesStrs.length; i++) {
             appendProp(sb, checkServicesStrs[i]);
         }


### PR DESCRIPTION
Add Firebird >3.0 compatibility for trace configuration file builder

Some RedDatabase parameters ar incompatible with firebird fbtrafe.conf:
  - format;
  - log_changes_only;
  - log_privilege_changes;
  - log_security_incidents; causing errors on starting trace.

Added option  'Firebird 3.0 or greater' in Server Version combobox. 
Added a new string array with the compatible parameters for Firebird 3.0 and greater. 
Added condition to prevent adding parameter 'format = 0' when using Server Version = 'Firebird 3.0 or greater'